### PR TITLE
feat: Add Rust native speedup with fluent retry DSL

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,8 @@ jobs:
         ruby-version: ['3.4']
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
       - name: Set up Ruby ${{ matrix.ruby-version }}
         uses: ruby/setup-ruby@v1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,12 @@
 /spec/reports/
 /tmp/
 Gemfile.lock
+
+# Rust/native extension build artifacts
+/ext/**/target/
+/ext/**/*.bundle
+/ext/**/*.dSYM/
+/ext/**/Makefile
+/ext/**/mkmf.log
+/ext/**/.sitearchdir.time
+/ext/**/Cargo.lock

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+      - id: check-merge-conflict
+      - id: check-case-conflict
+      - id: mixed-line-ending
+        args: [--fix=lf]

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'zeitwerk', '~> 2.7'
 
 # Platform specific gems (MRI Ruby only)
 platforms :mri do
-  gem 'async'
+  gem 'async', '~> 2.34'
   gem 'rbs', '~> 3.0'
+  gem 'rb_sys', '~> 0.9' # For building native extension
 end

--- a/chrono_machines.gemspec
+++ b/chrono_machines.gemspec
@@ -9,7 +9,10 @@ Gem::Specification.new do |spec|
   spec.email = ['terminale@gmail.com']
 
   spec.summary = 'A robust Ruby gem for implementing retry mechanisms with exponential backoff and jitter.'
-  spec.description = 'ChronoMachines offers a flexible and configurable solution for handling transient failures in distributed Ruby applications. It provides powerful retry strategies, including exponential backoff and full jitter, along with customizable callbacks for success, retry, and failure events. Define and manage retry policies with a clean DSL for seamless integration.'
+  spec.description = 'ChronoMachines offers a flexible and configurable solution for handling transient failures ' \
+                     'in distributed Ruby applications. It provides powerful retry strategies, including exponential ' \
+                     'backoff and full jitter, with customizable callbacks. Features optional Rust-powered native ' \
+                     'performance on CRuby with pure Ruby fallback for JRuby compatibility.'
   spec.homepage = 'https://github.com/seuros/chrono_machines'
   spec.license = 'MIT'
   spec.required_ruby_version = '>= 3.3.0'
@@ -22,13 +25,17 @@ Gem::Specification.new do |spec|
   spec.metadata['rubygems_mfa_required'] = 'true'
 
   spec.files = Dir.glob(%w[
-    lib/**/*.rb
-    sig/**/*.rbs
-    README.md
-    CHANGELOG.md
-    LICENSE.txt
-  ]).select { |f| File.exist?(f) }
+                          lib/**/*.rb
+                          sig/**/*.rbs
+                          ext/**/*.{rb,rs,toml}
+                          README.md
+                          CHANGELOG.md
+                          LICENSE.txt
+                        ]).select { |f| File.exist?(f) }
   spec.require_paths = ['lib']
+
+  # Add native extension (only on CRuby/TruffleRuby)
+  spec.extensions = ['ext/chrono_machines_native/extconf.rb'] unless RUBY_ENGINE == 'jruby'
 
   spec.add_dependency 'zeitwerk', '~> 2.7'
 end

--- a/ext/chrono_machines_native/Cargo.toml
+++ b/ext/chrono_machines_native/Cargo.toml
@@ -1,0 +1,7 @@
+[workspace]
+members = ["core", "ffi"]
+resolver = "2"
+
+[workspace.dependencies]
+chrono_machines = { path = "./core" }
+rand = { version = "0.8", default-features = false }

--- a/ext/chrono_machines_native/core/Cargo.toml
+++ b/ext/chrono_machines_native/core/Cargo.toml
@@ -19,6 +19,6 @@ default = ["std"]
 std = ["rand/std", "rand/std_rng"]
 
 [dependencies]
-rand = { workspace = true, features = ["small_rng"] }
+rand = { version = "0.8", default-features = false, features = ["small_rng"] }
 
 [dev-dependencies]

--- a/ext/chrono_machines_native/core/Cargo.toml
+++ b/ext/chrono_machines_native/core/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "chrono_machines"
+version = "0.1.0"
+edition = "2024"
+authors = ["Abdelkader Boudih <terminale@gmail.com>"]
+license = "MIT"
+description = "Pure Rust exponential backoff and retry library with full jitter"
+repository = "https://github.com/seuros/chrono_machines"
+keywords = ["retry", "backoff", "exponential", "jitter", "resilience"]
+categories = ["no-std", "algorithms"]
+readme = "README.md"
+
+[lib]
+name = "chrono_machines"
+crate-type = ["lib"]
+
+[features]
+default = ["std"]
+std = ["rand/std", "rand/std_rng"]
+
+[dependencies]
+rand = { workspace = true, features = ["small_rng"] }
+
+[dev-dependencies]

--- a/ext/chrono_machines_native/core/README.md
+++ b/ext/chrono_machines_native/core/README.md
@@ -89,10 +89,3 @@ You'll need to provide your own RNG and use `calculate_delay_with_rng()`.
 ## License
 
 MIT
-
-## Part of ChronoMachines Ecosystem
-
-This core library powers:
-- **chrono_machines** (Ruby gem) - via FFI
-- **chrono-machines-py** (Python) - via pyo3 *(planned)*
-- **chrono-machines** (Node.js) - via napi-rs *(planned)*

--- a/ext/chrono_machines_native/core/README.md
+++ b/ext/chrono_machines_native/core/README.md
@@ -1,0 +1,98 @@
+# ChronoMachines (Rust Core)
+
+Pure Rust exponential backoff and retry library with full jitter support.
+
+## Features
+
+- **Full Jitter**: Prevents thundering herd problem by randomizing delays
+- **`no_std` Compatible**: Works in embedded environments
+- **Zero Allocation**: Stack-only data structures
+- **Fast**: Minimal overhead for delay calculations
+- **Standalone**: No external dependencies besides `rand`
+
+## Usage
+
+Add to your `Cargo.toml`:
+
+```toml
+[dependencies]
+chrono_machines = "0.1"
+```
+
+### Basic Example
+
+```rust
+use chrono_machines::Policy;
+
+let policy = Policy {
+    max_attempts: 5,
+    base_delay_ms: 100,
+    multiplier: 2.0,
+    max_delay_ms: 10_000,
+};
+
+// Calculate delay for first retry using full jitter (1.0)
+let delay_ms = policy.calculate_delay(1, 1.0);
+println!("Wait {}ms before retry", delay_ms);
+```
+
+### With Custom RNG (no_std)
+
+```rust
+use chrono_machines::Policy;
+use rand::rngs::SmallRng;
+use rand::SeedableRng;
+
+let policy = Policy::default();
+let mut rng = SmallRng::seed_from_u64(12345);
+
+// Calculate delay with 50% jitter (0.5)
+let delay = policy.calculate_delay_with_rng(1, 0.5, &mut rng);
+```
+
+## Algorithm
+
+ChronoMachines implements **full jitter** exponential backoff:
+
+```
+delay = random(0, min(base * multiplier^(attempt-1), max))  // with jitter_factor = 1.0
+```
+
+This approach:
+1. Calculates exponential backoff: `base * multiplier^(attempt-1)`
+2. Caps at `max_delay_ms`
+3. Applies configurable jitter: blends between deterministic and random delay based on `jitter_factor`
+
+### Why Full Jitter?
+
+Full jitter prevents the "thundering herd" problem where multiple clients retry simultaneously,
+overwhelming a recovering service. By randomizing the delay, retries are naturally distributed
+over time.
+
+## Features
+
+### `std` (default)
+
+Enables standard library support and `StdRng` for `calculate_delay()` method.
+
+### `no_std`
+
+Disable default features for `no_std` environments:
+
+```toml
+[dependencies]
+chrono_machines = { version = "0.1", default-features = false }
+```
+
+You'll need to provide your own RNG and use `calculate_delay_with_rng()`.
+
+## License
+
+MIT
+
+## Part of ChronoMachines Ecosystem
+
+This core library powers:
+- **chrono_machines** (Ruby gem) - via FFI
+- **chrono-machines-py** (Python) - via pyo3 *(planned)*
+- **chrono-machines** (Node.js) - via napi-rs *(planned)*

--- a/ext/chrono_machines_native/core/examples/blocking_retry.rs
+++ b/ext/chrono_machines_native/core/examples/blocking_retry.rs
@@ -1,0 +1,123 @@
+//! Blocking retry example
+//!
+//! Demonstrates using chrono_machines for synchronous retry operations
+//! with the standard library sleeper.
+//!
+//! Run with: cargo run --example blocking_retry --features std
+
+use chrono_machines::{ConstantBackoff, ExponentialBackoff, FibonacciBackoff, Retryable};
+
+#[derive(Debug)]
+enum ApiError {
+    Timeout,
+    RateLimited,
+    ServerError,
+    NotFound,
+}
+
+fn main() {
+    println!("=== ChronoMachines Blocking Retry Examples ===\n");
+
+    // Example 1: Exponential backoff with success after retries
+    println!("1. Exponential Backoff - Success after retries:");
+    let mut attempt_count = 0;
+    let result = (|| {
+        attempt_count += 1;
+        println!("   Attempt {}", attempt_count);
+
+        if attempt_count < 3 {
+            Err(ApiError::Timeout)
+        } else {
+            Ok("Success!")
+        }
+    })
+    .retry(
+        ExponentialBackoff::new()
+            .base_delay_ms(100)
+            .multiplier(2.0)
+            .max_attempts(5)
+            .jitter_factor(0.1), // 10% jitter
+    )
+    .notify(|err, delay_ms| {
+        println!("   → Retrying after {}ms due to: {:?}", delay_ms, err);
+    })
+    .call();
+
+    println!("   Result: {:?}\n", result);
+
+    // Example 2: Constant backoff with conditional retry
+    println!("2. Constant Backoff - Conditional retry (only timeout):");
+    attempt_count = 0;
+    let result: Result<&str, _> = (|| {
+        attempt_count += 1;
+        println!("   Attempt {}", attempt_count);
+
+        if attempt_count == 1 {
+            Err(ApiError::Timeout)
+        } else {
+            Err(ApiError::NotFound) // Non-retryable
+        }
+    })
+    .retry(
+        ConstantBackoff::new()
+            .delay_ms(50)
+            .max_attempts(3)
+            .jitter_factor(0.0),
+    )
+    .when(|e| matches!(e, ApiError::Timeout | ApiError::RateLimited))
+    .notify(|err, delay_ms| {
+        println!("   → Retrying after {}ms due to: {:?}", delay_ms, err);
+    })
+    .call();
+
+    println!("   Result: {:?}\n", result);
+
+    // Example 3: Fibonacci backoff
+    println!("3. Fibonacci Backoff - Progressive delays:");
+    attempt_count = 0;
+    let result = (|| {
+        attempt_count += 1;
+        println!("   Attempt {}", attempt_count);
+
+        if attempt_count < 4 {
+            Err(ApiError::ServerError)
+        } else {
+            Ok(42)
+        }
+    })
+    .retry(
+        FibonacciBackoff::new()
+            .base_delay_ms(50) // 50ms, 50ms, 100ms, 150ms, 250ms...
+            .max_attempts(5)
+            .jitter_factor(0.0), // No jitter for predictable timing
+    )
+    .notify(|err, delay_ms| {
+        println!("   → Retrying after {}ms due to: {:?}", delay_ms, err);
+    })
+    .call();
+
+    println!("   Result: {:?}\n", result);
+
+    // Example 4: Retry exhausted
+    println!("4. Retry Exhausted - Max attempts reached:");
+    attempt_count = 0;
+    let result: Result<&str, _> = (|| {
+        attempt_count += 1;
+        println!("   Attempt {}", attempt_count);
+        Err(ApiError::ServerError)
+    })
+    .retry(
+        ExponentialBackoff::new()
+            .base_delay_ms(10)
+            .max_attempts(3)
+            .jitter_factor(0.0),
+    )
+    .notify(|err, delay_ms| {
+        println!("   → Retrying after {}ms due to: {:?}", delay_ms, err);
+    })
+    .call();
+
+    println!("   Result: {:?}", result);
+
+    println!("\n=== All examples completed ===");
+}

--- a/ext/chrono_machines_native/core/src/backoff.rs
+++ b/ext/chrono_machines_native/core/src/backoff.rs
@@ -1,0 +1,421 @@
+//! Backoff strategy implementations for retry mechanisms
+//!
+//! This module provides various backoff strategies to control delay timing
+//! between retry attempts.
+
+use rand::Rng;
+
+/// Trait for backoff strategies that calculate delays between retry attempts
+pub trait BackoffStrategy {
+    /// Calculate the delay in milliseconds for the given attempt number
+    ///
+    /// # Arguments
+    ///
+    /// * `attempt` - Current attempt number (1-indexed)
+    /// * `rng` - Random number generator for jitter
+    ///
+    /// # Returns
+    ///
+    /// Delay in milliseconds, or `None` if retries should stop
+    fn delay<R: Rng>(&self, attempt: u8, rng: &mut R) -> Option<u64>;
+
+    /// Check if another retry should be attempted
+    ///
+    /// # Arguments
+    ///
+    /// * `attempt` - Current attempt number (1-indexed)
+    ///
+    /// # Returns
+    ///
+    /// `true` if another retry is allowed, `false` otherwise
+    fn should_retry(&self, attempt: u8) -> bool;
+}
+
+/// Exponential backoff strategy with configurable jitter
+///
+/// Delays grow exponentially: base_delay * multiplier^(attempt-1)
+///
+/// # Example
+///
+/// ```rust
+/// use chrono_machines::ExponentialBackoff;
+///
+/// let backoff = ExponentialBackoff::new()
+///     .base_delay_ms(100)
+///     .multiplier(2.0)
+///     .max_delay_ms(10_000)
+///     .max_attempts(5)
+///     .jitter_factor(1.0); // Full jitter
+/// ```
+#[derive(Debug, Clone, Copy)]
+pub struct ExponentialBackoff {
+    /// Maximum number of retry attempts
+    pub max_attempts: u8,
+    /// Base delay in milliseconds
+    pub base_delay_ms: u64,
+    /// Exponential backoff multiplier
+    pub multiplier: f64,
+    /// Maximum delay cap in milliseconds
+    pub max_delay_ms: u64,
+    /// Jitter factor (0.0 = no jitter, 1.0 = full jitter)
+    pub jitter_factor: f64,
+}
+
+impl ExponentialBackoff {
+    /// Create a new exponential backoff builder with default values
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the base delay in milliseconds
+    pub fn base_delay_ms(mut self, ms: u64) -> Self {
+        self.base_delay_ms = ms;
+        self
+    }
+
+    /// Set the exponential multiplier
+    pub fn multiplier(mut self, multiplier: f64) -> Self {
+        self.multiplier = multiplier;
+        self
+    }
+
+    /// Set the maximum delay cap in milliseconds
+    pub fn max_delay_ms(mut self, ms: u64) -> Self {
+        self.max_delay_ms = ms;
+        self
+    }
+
+    /// Set the maximum number of attempts
+    pub fn max_attempts(mut self, attempts: u8) -> Self {
+        self.max_attempts = attempts;
+        self
+    }
+
+    /// Set the jitter factor (0.0 = no jitter, 1.0 = full jitter)
+    pub fn jitter_factor(mut self, factor: f64) -> Self {
+        self.jitter_factor = factor.clamp(0.0, 1.0);
+        self
+    }
+}
+
+impl Default for ExponentialBackoff {
+    fn default() -> Self {
+        Self {
+            max_attempts: 3,
+            base_delay_ms: 100,
+            multiplier: 2.0,
+            max_delay_ms: 10_000,
+            jitter_factor: 1.0, // Full jitter by default
+        }
+    }
+}
+
+impl BackoffStrategy for ExponentialBackoff {
+    fn delay<R: Rng>(&self, attempt: u8, rng: &mut R) -> Option<u64> {
+        if attempt >= self.max_attempts {
+            return None;
+        }
+
+        let jitter_factor = self.jitter_factor.clamp(0.0, 1.0);
+        let exponent = attempt.saturating_sub(1) as i32;
+        let base_exponential = (self.base_delay_ms as f64) * self.multiplier.powi(exponent);
+        let capped = base_exponential.min(self.max_delay_ms as f64);
+
+        // Apply jitter blend
+        let random_scalar: f64 = rng.gen_range(0.0..=1.0);
+        let jitter_blend = 1.0 - jitter_factor + random_scalar * jitter_factor;
+        let jittered = capped * jitter_blend;
+
+        Some(jittered as u64)
+    }
+
+    fn should_retry(&self, attempt: u8) -> bool {
+        attempt < self.max_attempts
+    }
+}
+
+/// Constant backoff strategy with fixed delay
+///
+/// All retry delays are the same constant value.
+///
+/// # Example
+///
+/// ```rust
+/// use chrono_machines::ConstantBackoff;
+///
+/// let backoff = ConstantBackoff::new()
+///     .delay_ms(500)
+///     .max_attempts(5)
+///     .jitter_factor(0.1); // 10% jitter
+/// ```
+#[derive(Debug, Clone, Copy)]
+pub struct ConstantBackoff {
+    /// Fixed delay in milliseconds
+    pub delay_ms: u64,
+    /// Maximum number of retry attempts
+    pub max_attempts: u8,
+    /// Jitter factor (0.0 = no jitter, 1.0 = full jitter)
+    pub jitter_factor: f64,
+}
+
+impl ConstantBackoff {
+    /// Create a new constant backoff builder with default values
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the constant delay in milliseconds
+    pub fn delay_ms(mut self, ms: u64) -> Self {
+        self.delay_ms = ms;
+        self
+    }
+
+    /// Set the maximum number of attempts
+    pub fn max_attempts(mut self, attempts: u8) -> Self {
+        self.max_attempts = attempts;
+        self
+    }
+
+    /// Set the jitter factor (0.0 = no jitter, 1.0 = full jitter)
+    pub fn jitter_factor(mut self, factor: f64) -> Self {
+        self.jitter_factor = factor.clamp(0.0, 1.0);
+        self
+    }
+}
+
+impl Default for ConstantBackoff {
+    fn default() -> Self {
+        Self {
+            delay_ms: 100,
+            max_attempts: 3,
+            jitter_factor: 0.0, // No jitter for constant by default
+        }
+    }
+}
+
+impl BackoffStrategy for ConstantBackoff {
+    fn delay<R: Rng>(&self, attempt: u8, rng: &mut R) -> Option<u64> {
+        if attempt >= self.max_attempts {
+            return None;
+        }
+
+        let jitter_factor = self.jitter_factor.clamp(0.0, 1.0);
+        let base = self.delay_ms as f64;
+
+        // Apply jitter blend
+        let random_scalar: f64 = rng.gen_range(0.0..=1.0);
+        let jitter_blend = 1.0 - jitter_factor + random_scalar * jitter_factor;
+        let jittered = base * jitter_blend;
+
+        Some(jittered as u64)
+    }
+
+    fn should_retry(&self, attempt: u8) -> bool {
+        attempt < self.max_attempts
+    }
+}
+
+/// Fibonacci backoff strategy
+///
+/// Delays follow the Fibonacci sequence: 1, 1, 2, 3, 5, 8, 13, ...
+/// Each delay is base_delay_ms * fibonacci(attempt).
+///
+/// # Example
+///
+/// ```rust
+/// use chrono_machines::FibonacciBackoff;
+///
+/// let backoff = FibonacciBackoff::new()
+///     .base_delay_ms(100)  // 100ms, 100ms, 200ms, 300ms, 500ms...
+///     .max_delay_ms(5_000)
+///     .max_attempts(8)
+///     .jitter_factor(0.5); // 50% jitter
+/// ```
+#[derive(Debug, Clone, Copy)]
+pub struct FibonacciBackoff {
+    /// Base delay in milliseconds (multiplied by Fibonacci number)
+    pub base_delay_ms: u64,
+    /// Maximum delay cap in milliseconds
+    pub max_delay_ms: u64,
+    /// Maximum number of retry attempts
+    pub max_attempts: u8,
+    /// Jitter factor (0.0 = no jitter, 1.0 = full jitter)
+    pub jitter_factor: f64,
+}
+
+impl FibonacciBackoff {
+    /// Create a new Fibonacci backoff builder with default values
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the base delay in milliseconds
+    pub fn base_delay_ms(mut self, ms: u64) -> Self {
+        self.base_delay_ms = ms;
+        self
+    }
+
+    /// Set the maximum delay cap in milliseconds
+    pub fn max_delay_ms(mut self, ms: u64) -> Self {
+        self.max_delay_ms = ms;
+        self
+    }
+
+    /// Set the maximum number of attempts
+    pub fn max_attempts(mut self, attempts: u8) -> Self {
+        self.max_attempts = attempts;
+        self
+    }
+
+    /// Set the jitter factor (0.0 = no jitter, 1.0 = full jitter)
+    pub fn jitter_factor(mut self, factor: f64) -> Self {
+        self.jitter_factor = factor.clamp(0.0, 1.0);
+        self
+    }
+
+    /// Calculate the nth Fibonacci number (1-indexed)
+    fn fibonacci(n: u8) -> u64 {
+        match n {
+            0 => 0,
+            1 | 2 => 1,
+            _ => {
+                let mut a = 1u64;
+                let mut b = 1u64;
+                for _ in 2..n {
+                    let next = a.saturating_add(b);
+                    a = b;
+                    b = next;
+                }
+                b
+            }
+        }
+    }
+}
+
+impl Default for FibonacciBackoff {
+    fn default() -> Self {
+        Self {
+            base_delay_ms: 100,
+            max_delay_ms: 10_000,
+            max_attempts: 8,
+            jitter_factor: 1.0, // Full jitter by default
+        }
+    }
+}
+
+impl BackoffStrategy for FibonacciBackoff {
+    fn delay<R: Rng>(&self, attempt: u8, rng: &mut R) -> Option<u64> {
+        if attempt >= self.max_attempts {
+            return None;
+        }
+
+        let jitter_factor = self.jitter_factor.clamp(0.0, 1.0);
+        let fib = Self::fibonacci(attempt);
+        let base = ((self.base_delay_ms as f64) * (fib as f64)).min(self.max_delay_ms as f64);
+
+        // Apply jitter blend
+        let random_scalar: f64 = rng.gen_range(0.0..=1.0);
+        let jitter_blend = 1.0 - jitter_factor + random_scalar * jitter_factor;
+        let jittered = base * jitter_blend;
+
+        Some(jittered as u64)
+    }
+
+    fn should_retry(&self, attempt: u8) -> bool {
+        attempt < self.max_attempts
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::rngs::SmallRng;
+    use rand::SeedableRng;
+
+    #[test]
+    fn test_exponential_backoff_builder() {
+        let backoff = ExponentialBackoff::new()
+            .base_delay_ms(200)
+            .multiplier(3.0)
+            .max_delay_ms(5000)
+            .max_attempts(5)
+            .jitter_factor(0.5);
+
+        assert_eq!(backoff.base_delay_ms, 200);
+        assert_eq!(backoff.multiplier, 3.0);
+        assert_eq!(backoff.max_delay_ms, 5000);
+        assert_eq!(backoff.max_attempts, 5);
+        assert_eq!(backoff.jitter_factor, 0.5);
+    }
+
+    #[test]
+    fn test_exponential_delays() {
+        let backoff = ExponentialBackoff::new()
+            .base_delay_ms(100)
+            .multiplier(2.0)
+            .jitter_factor(0.0); // No jitter for predictable testing
+
+        let mut rng = SmallRng::seed_from_u64(42);
+
+        assert_eq!(backoff.delay(1, &mut rng), Some(100));
+        assert_eq!(backoff.delay(2, &mut rng), Some(200));
+        assert_eq!(backoff.delay(3, &mut rng), None); // Exceeds max_attempts (default 3)
+    }
+
+    #[test]
+    fn test_constant_backoff() {
+        let backoff = ConstantBackoff::new()
+            .delay_ms(500)
+            .max_attempts(4)
+            .jitter_factor(0.0);
+
+        let mut rng = SmallRng::seed_from_u64(42);
+
+        assert_eq!(backoff.delay(1, &mut rng), Some(500));
+        assert_eq!(backoff.delay(2, &mut rng), Some(500));
+        assert_eq!(backoff.delay(3, &mut rng), Some(500));
+        assert_eq!(backoff.delay(4, &mut rng), None);
+    }
+
+    #[test]
+    fn test_fibonacci_sequence() {
+        assert_eq!(FibonacciBackoff::fibonacci(1), 1);
+        assert_eq!(FibonacciBackoff::fibonacci(2), 1);
+        assert_eq!(FibonacciBackoff::fibonacci(3), 2);
+        assert_eq!(FibonacciBackoff::fibonacci(4), 3);
+        assert_eq!(FibonacciBackoff::fibonacci(5), 5);
+        assert_eq!(FibonacciBackoff::fibonacci(6), 8);
+        assert_eq!(FibonacciBackoff::fibonacci(7), 13);
+    }
+
+    #[test]
+    fn test_fibonacci_backoff() {
+        let backoff = FibonacciBackoff::new()
+            .base_delay_ms(100)
+            .max_attempts(5)
+            .jitter_factor(0.0);
+
+        let mut rng = SmallRng::seed_from_u64(42);
+
+        assert_eq!(backoff.delay(1, &mut rng), Some(100)); // 100 * 1
+        assert_eq!(backoff.delay(2, &mut rng), Some(100)); // 100 * 1
+        assert_eq!(backoff.delay(3, &mut rng), Some(200)); // 100 * 2
+        assert_eq!(backoff.delay(4, &mut rng), Some(300)); // 100 * 3
+        assert_eq!(backoff.delay(5, &mut rng), None); // Exceeds max_attempts
+    }
+
+    #[test]
+    fn test_jitter_application() {
+        let backoff = ConstantBackoff::new().delay_ms(1000).jitter_factor(1.0); // Full jitter
+
+        let mut rng = SmallRng::seed_from_u64(42);
+        let delays: Vec<u64> = (1..10).filter_map(|i| backoff.delay(i, &mut rng)).collect();
+
+        // With full jitter, delays should vary
+        let all_different = delays.windows(2).any(|w| w[0] != w[1]);
+        assert!(all_different, "Full jitter should produce varying delays");
+
+        // All delays should be <= base delay
+        assert!(delays.iter().all(|&d| d <= 1000));
+    }
+}

--- a/ext/chrono_machines_native/core/src/lib.rs
+++ b/ext/chrono_machines_native/core/src/lib.rs
@@ -1,0 +1,322 @@
+//! ChronoMachines - Pure Rust exponential backoff and retry library
+//!
+//! This crate provides a lightweight, `no_std` compatible implementation of
+//! exponential backoff with full jitter for retry mechanisms.
+//!
+//! # Features
+//!
+//! - **Full Jitter**: Prevents thundering herd problem
+//! - **no_std compatible**: Works in embedded environments
+//! - **Zero allocation**: Uses stack-only data structures
+//! - **Fast**: Minimal overhead for delay calculations
+//!
+//! # Example
+//!
+//! ```rust
+//! use chrono_machines::Policy;
+//!
+//! let policy = Policy {
+//!     max_attempts: 5,
+//!     base_delay_ms: 100,
+//!     multiplier: 2.0,
+//!     max_delay_ms: 10_000,
+//! };
+//!
+//! // Use full jitter (1.0) - recommended for distributed systems
+//! let delay = policy.calculate_delay(1, 1.0);
+//! println!("Wait {}ms before retry", delay);
+//! ```
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(feature = "std")]
+use rand::rngs::StdRng;
+#[cfg(feature = "std")]
+use rand::SeedableRng;
+
+use rand::Rng;
+
+/// Retry policy configuration
+///
+/// Defines the parameters for exponential backoff with jitter.
+#[derive(Debug, Clone, Copy)]
+pub struct Policy {
+    /// Maximum number of retry attempts
+    pub max_attempts: u8,
+
+    /// Base delay in milliseconds
+    pub base_delay_ms: u64,
+
+    /// Exponential backoff multiplier
+    pub multiplier: f64,
+
+    /// Maximum delay cap in milliseconds
+    pub max_delay_ms: u64,
+}
+
+impl Policy {
+    /// Create a new policy with default values
+    ///
+    /// # Default values
+    ///
+    /// - `max_attempts`: 3
+    /// - `base_delay_ms`: 100
+    /// - `multiplier`: 2.0
+    /// - `max_delay_ms`: 10_000
+    pub fn new() -> Self {
+        Self {
+            max_attempts: 3,
+            base_delay_ms: 100,
+            multiplier: 2.0,
+            max_delay_ms: 10_000,
+        }
+    }
+
+    /// Calculate delay with jitter for the given attempt
+    ///
+    /// Applies exponential backoff with configurable jitter to prevent
+    /// thundering herd problems in distributed systems.
+    ///
+    /// # Arguments
+    ///
+    /// * `attempt` - Current attempt number (1-indexed)
+    /// * `jitter_factor` - Jitter multiplier (0.0 = no jitter, 1.0 = full jitter)
+    ///
+    /// # Returns
+    ///
+    /// Delay in milliseconds as a `u64`
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use chrono_machines::Policy;
+    ///
+    /// let policy = Policy::new();
+    /// // Full jitter (default behavior)
+    /// let delay = policy.calculate_delay(1, 1.0);
+    /// assert!(delay <= 100); // First attempt, max is base_delay_ms
+    ///
+    /// // 10% jitter - delay will be 90-100% of base_delay_ms
+    /// let delay = policy.calculate_delay(1, 0.1);
+    /// assert!(delay >= 90 && delay <= 100);
+    /// ```
+    #[cfg(feature = "std")]
+    pub fn calculate_delay(&self, attempt: u8, jitter_factor: f64) -> u64 {
+        let mut rng = StdRng::from_entropy();
+        self.calculate_delay_with_rng(attempt, jitter_factor, &mut rng)
+    }
+
+    /// Calculate delay with a provided RNG and custom jitter factor
+    ///
+    /// This method allows for custom RNG implementations and jitter control, useful for:
+    /// - Deterministic testing
+    /// - `no_std` environments with custom RNG sources
+    /// - Performance optimization with specific RNG types
+    /// - Fine-tuning jitter behavior
+    ///
+    /// # Arguments
+    ///
+    /// * `attempt` - Current attempt number (1-indexed)
+    /// * `jitter_factor` - Jitter multiplier (0.0 = no jitter, 1.0 = full jitter)
+    /// * `rng` - Random number generator implementing `Rng`
+    ///
+    /// # Returns
+    ///
+    /// Delay in milliseconds as a `u64`
+    pub fn calculate_delay_with_rng<R: Rng>(
+        &self,
+        attempt: u8,
+        jitter_factor: f64,
+        rng: &mut R,
+    ) -> u64 {
+        // Normalize jitter factor to the inclusive range [0.0, 1.0]
+        let mut jitter_factor = jitter_factor;
+        if jitter_factor.is_nan() {
+            jitter_factor = 1.0;
+        } else {
+            jitter_factor = jitter_factor.clamp(0.0, 1.0);
+        }
+
+        // Calculate base exponential backoff
+        let exponent = attempt.saturating_sub(1) as i32;
+        let base_exponential = (self.base_delay_ms as f64) * self.multiplier.powi(exponent);
+
+        // Cap at max_delay
+        let capped = base_exponential.min(self.max_delay_ms as f64);
+
+        // Apply jitter: blend between deterministic and random delay
+        // jitter_factor of 1.0 = full jitter (0 to base), 0.0 = no jitter (exactly base)
+        // Formula: base * (1 - jitter_factor + rand * jitter_factor)
+        // Example with jitter_factor=0.1: base * (0.9 + rand*0.1) = 90% to 100% of base
+        let random_scalar: f64 = rng.gen_range(0.0..=1.0);
+        let jitter_blend = 1.0 - jitter_factor + random_scalar * jitter_factor;
+        let jittered = capped * jitter_blend;
+
+        jittered as u64
+    }
+
+    /// Check if another retry should be attempted
+    ///
+    /// # Arguments
+    ///
+    /// * `current_attempt` - Current attempt number (1-indexed)
+    ///
+    /// # Returns
+    ///
+    /// `true` if another retry is allowed, `false` otherwise
+    pub fn should_retry(&self, current_attempt: u8) -> bool {
+        current_attempt < self.max_attempts
+    }
+}
+
+impl Default for Policy {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::rngs::SmallRng;
+    use rand::SeedableRng;
+
+    #[test]
+    fn test_policy_default() {
+        let policy = Policy::default();
+        assert_eq!(policy.max_attempts, 3);
+        assert_eq!(policy.base_delay_ms, 100);
+        assert_eq!(policy.multiplier, 2.0);
+        assert_eq!(policy.max_delay_ms, 10_000);
+    }
+
+    #[test]
+    fn test_calculate_delay_bounds() {
+        let policy = Policy {
+            max_attempts: 5,
+            base_delay_ms: 100,
+            multiplier: 2.0,
+            max_delay_ms: 1000,
+        };
+
+        let mut rng = SmallRng::seed_from_u64(42);
+
+        // First attempt with full jitter: delay should be between 0 and 100ms
+        let delay1 = policy.calculate_delay_with_rng(1, 1.0, &mut rng);
+        assert!(delay1 <= 100);
+
+        // Second attempt with full jitter: delay should be between 0 and 200ms
+        let delay2 = policy.calculate_delay_with_rng(2, 1.0, &mut rng);
+        assert!(delay2 <= 200);
+
+        // Fifth attempt with full jitter: delay should be capped at max_delay_ms (1000ms)
+        let delay5 = policy.calculate_delay_with_rng(5, 1.0, &mut rng);
+        assert!(delay5 <= 1000);
+    }
+
+    #[test]
+    fn test_should_retry() {
+        let policy = Policy {
+            max_attempts: 3,
+            ..Policy::default()
+        };
+
+        assert!(policy.should_retry(1));
+        assert!(policy.should_retry(2));
+        assert!(!policy.should_retry(3));
+        assert!(!policy.should_retry(4));
+    }
+
+    #[test]
+    fn test_max_delay_cap() {
+        let policy = Policy {
+            max_attempts: 10,
+            base_delay_ms: 100,
+            multiplier: 2.0,
+            max_delay_ms: 500,
+        };
+
+        let mut rng = SmallRng::seed_from_u64(42);
+
+        // High attempt number should still be capped
+        let delay = policy.calculate_delay_with_rng(10, 1.0, &mut rng);
+        assert!(delay <= 500);
+    }
+
+    #[test]
+    fn test_zero_multiplier() {
+        let policy = Policy {
+            max_attempts: 5,
+            base_delay_ms: 100,
+            multiplier: 1.0, // No exponential growth
+            max_delay_ms: 10_000,
+        };
+
+        let mut rng = SmallRng::seed_from_u64(42);
+
+        // All delays with full jitter should be between 0 and base_delay_ms
+        for attempt in 1..=5 {
+            let delay = policy.calculate_delay_with_rng(attempt, 1.0, &mut rng);
+            assert!(delay <= 100);
+        }
+    }
+
+    #[test]
+    fn test_jitter_factor() {
+        let policy = Policy {
+            max_attempts: 5,
+            base_delay_ms: 1000,
+            multiplier: 1.0,
+            max_delay_ms: 10_000,
+        };
+
+        let mut rng = SmallRng::seed_from_u64(42);
+
+        // 10% jitter: delay should be between 900ms (90%) and 1000ms (100%)
+        let delay = policy.calculate_delay_with_rng(1, 0.1, &mut rng);
+        assert!(
+            delay >= 900 && delay <= 1000,
+            "delay {} not in range 900-1000",
+            delay
+        );
+
+        // No jitter: delay should be exactly base_delay_ms
+        let delay = policy.calculate_delay_with_rng(1, 0.0, &mut rng);
+        assert_eq!(delay, 1000);
+
+        // Full jitter: delay should be between 0 and 1000ms
+        let delay = policy.calculate_delay_with_rng(1, 1.0, &mut rng);
+        assert!(delay <= 1000);
+    }
+
+    #[test]
+    fn test_jitter_factor_clamping() {
+        let policy = Policy {
+            max_attempts: 5,
+            base_delay_ms: 1000,
+            multiplier: 1.0,
+            max_delay_ms: 10_000,
+        };
+
+        let mut rng = SmallRng::seed_from_u64(42);
+
+        // Negative jitter_factor should be clamped to 0.0
+        let delay = policy.calculate_delay_with_rng(1, -0.5, &mut rng);
+        assert_eq!(delay, 1000, "negative jitter_factor should clamp to 0.0");
+
+        // jitter_factor > 1.0 should be clamped to 1.0
+        let delay = policy.calculate_delay_with_rng(1, 2.0, &mut rng);
+        assert!(
+            delay <= 1000,
+            "jitter_factor > 1.0 should clamp to 1.0, got delay {}",
+            delay
+        );
+
+        // Extreme values should still be clamped
+        let delay = policy.calculate_delay_with_rng(1, 999.0, &mut rng);
+        assert!(delay <= 1000, "extreme jitter_factor should be clamped");
+
+        let delay = policy.calculate_delay_with_rng(1, -999.0, &mut rng);
+        assert_eq!(delay, 1000, "extreme negative should clamp to 0.0");
+    }
+}

--- a/ext/chrono_machines_native/core/src/retry.rs
+++ b/ext/chrono_machines_native/core/src/retry.rs
@@ -1,0 +1,430 @@
+//! Retry mechanism with fluent builder API
+//!
+//! This module provides a fluent retry API for wrapping fallible operations
+//! with automatic retries and configurable backoff strategies.
+
+use crate::backoff::BackoffStrategy;
+use crate::sleep::Sleeper;
+use rand::rngs::SmallRng;
+use rand::SeedableRng;
+
+/// Extension trait that adds `.retry()` method to functions and closures
+///
+/// This trait is automatically implemented for all `Fn` types that return `Result`.
+///
+/// # Example
+///
+/// ```rust
+/// use chrono_machines::{Retryable, ExponentialBackoff};
+///
+/// fn fetch_data() -> Result<String, std::io::Error> {
+///     // ... operation that might fail
+/// #   Ok("data".to_string())
+/// }
+///
+/// # #[cfg(feature = "std")]
+/// let result = fetch_data
+///     .retry(ExponentialBackoff::default())
+///     .call();
+/// ```
+pub trait Retryable<T, E> {
+    /// Begin building a retry operation with the given backoff strategy
+    ///
+    /// # Arguments
+    ///
+    /// * `backoff` - The backoff strategy to use for retry delays
+    ///
+    /// # Returns
+    ///
+    /// A `RetryBuilder` that can be further configured before execution
+    fn retry<B: BackoffStrategy>(self, backoff: B) -> RetryBuilder<Self, B, T, E, fn(&E) -> bool>
+    where
+        Self: Sized;
+}
+
+impl<F, T, E> Retryable<T, E> for F
+where
+    F: FnMut() -> Result<T, E>,
+{
+    fn retry<B: BackoffStrategy>(self, backoff: B) -> RetryBuilder<Self, B, T, E, fn(&E) -> bool> {
+        RetryBuilder {
+            operation: self,
+            backoff,
+            when: None,
+            notify: None,
+            _phantom_t: core::marker::PhantomData,
+            _phantom_e: core::marker::PhantomData,
+        }
+    }
+}
+
+/// Builder for configuring and executing retry operations
+///
+/// Created by calling `.retry()` on a function or closure.
+/// Provides a fluent API for configuring retry behavior.
+///
+/// # Type Parameters
+///
+/// * `F` - The operation function type
+/// * `B` - The backoff strategy type
+/// * `T` - The success return type
+/// * `E` - The error type
+/// * `W` - The when predicate type
+pub struct RetryBuilder<F, B, T, E, W> {
+    operation: F,
+    backoff: B,
+    when: Option<W>,
+    notify: Option<fn(&E, u64)>,
+    _phantom_t: core::marker::PhantomData<T>,
+    _phantom_e: core::marker::PhantomData<E>,
+}
+
+impl<F, B, T, E, W> RetryBuilder<F, B, T, E, W>
+where
+    F: FnMut() -> Result<T, E>,
+    B: BackoffStrategy,
+    W: Fn(&E) -> bool,
+{
+    /// Add a conditional predicate that determines if an error should trigger retry
+    ///
+    /// Only errors where `predicate(&error)` returns `true` will be retried.
+    /// Errors that don't match the predicate are returned immediately without retry.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use chrono_machines::{Retryable, ExponentialBackoff};
+    ///
+    /// #[derive(Debug)]
+    /// enum MyError {
+    ///     Retryable,
+    ///     Fatal,
+    /// }
+    ///
+    /// fn risky_operation() -> Result<String, MyError> {
+    ///     // ...
+    /// #   Err(MyError::Retryable)
+    /// }
+    ///
+    /// # #[cfg(feature = "std")]
+    /// let result = risky_operation
+    ///     .retry(ExponentialBackoff::default())
+    ///     .when(|e| matches!(e, MyError::Retryable))
+    ///     .call();
+    /// ```
+    pub fn when<P>(self, predicate: P) -> RetryBuilder<F, B, T, E, P>
+    where
+        P: Fn(&E) -> bool,
+    {
+        RetryBuilder {
+            operation: self.operation,
+            backoff: self.backoff,
+            when: Some(predicate),
+            notify: self.notify,
+            _phantom_t: core::marker::PhantomData,
+            _phantom_e: core::marker::PhantomData,
+        }
+    }
+
+    /// Add a notification callback that's invoked before each retry
+    ///
+    /// The callback receives the error that triggered the retry and the
+    /// delay in milliseconds before the next attempt.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use chrono_machines::{Retryable, ExponentialBackoff};
+    ///
+    /// fn fetch_data() -> Result<String, std::io::Error> {
+    ///     // ...
+    /// #   Ok("data".to_string())
+    /// }
+    ///
+    /// # #[cfg(feature = "std")]
+    /// let result = fetch_data
+    ///     .retry(ExponentialBackoff::default())
+    ///     .notify(|err, delay_ms| {
+    ///         println!("Retrying after {}ms: {:?}", delay_ms, err);
+    ///     })
+    ///     .call();
+    /// ```
+    pub fn notify(mut self, callback: fn(&E, u64)) -> Self {
+        self.notify = Some(callback);
+        self
+    }
+
+    /// Execute the retry operation with blocking sleep (requires `std` feature)
+    ///
+    /// Runs the operation synchronously, retrying with blocking sleep between attempts.
+    ///
+    /// # Returns
+    ///
+    /// The final result after all retry attempts (success or final error)
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use chrono_machines::{Retryable, ExponentialBackoff};
+    ///
+    /// fn fetch_data() -> Result<String, std::io::Error> {
+    ///     // ...
+    /// #   Ok("data".to_string())
+    /// }
+    ///
+    /// # #[cfg(feature = "std")]
+    /// let result = fetch_data
+    ///     .retry(ExponentialBackoff::default())
+    ///     .call()?;
+    /// # Ok::<(), std::io::Error>(())
+    /// ```
+    #[cfg(feature = "std")]
+    pub fn call(self) -> Result<T, E> {
+        use crate::sleep::StdSleeper;
+        self.call_with_sleeper(StdSleeper)
+    }
+
+    /// Execute the retry operation with a custom sleeper
+    ///
+    /// This low-level method allows providing a custom sleep implementation,
+    /// enabling support for async runtimes, embedded systems, or testing.
+    ///
+    /// # Arguments
+    ///
+    /// * `sleeper` - Implementation of the `Sleeper` trait
+    ///
+    /// # Returns
+    ///
+    /// The final result after all retry attempts
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use chrono_machines::{Retryable, ExponentialBackoff, sleep::{FnSleeper, Sleeper}};
+    ///
+    /// fn fetch_data() -> Result<String, std::io::Error> {
+    ///     Ok("data".to_string())
+    /// }
+    ///
+    /// fn custom_sleep(ms: u64) {
+    ///     // Custom sleep implementation
+    /// #   std::thread::sleep(std::time::Duration::from_millis(ms));
+    /// }
+    ///
+    /// let result = fetch_data
+    ///     .retry(ExponentialBackoff::default())
+    ///     .call_with_sleeper(FnSleeper(custom_sleep))?;
+    /// # Ok::<(), std::io::Error>(())
+    /// ```
+    pub fn call_with_sleeper<S: Sleeper>(mut self, sleeper: S) -> Result<T, E> {
+        let mut rng = SmallRng::from_entropy();
+        let mut attempt = 1u8;
+
+        loop {
+            match (self.operation)() {
+                Ok(value) => return Ok(value),
+                Err(error) => {
+                    // Check if this error should be retried
+                    if let Some(ref predicate) = self.when {
+                        if !predicate(&error) {
+                            // Error doesn't match predicate, fail immediately
+                            return Err(error);
+                        }
+                    }
+
+                    // Check if we have retries remaining
+                    if !self.backoff.should_retry(attempt) {
+                        return Err(error);
+                    }
+
+                    // Calculate delay
+                    match self.backoff.delay(attempt, &mut rng) {
+                        Some(delay_ms) => {
+                            // Notify if callback is set
+                            if let Some(notify) = self.notify {
+                                notify(&error, delay_ms);
+                            }
+
+                            // Sleep before retry
+                            sleeper.sleep_ms(delay_ms);
+                            attempt += 1;
+                        }
+                        None => {
+                            // Backoff says no more retries
+                            return Err(error);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backoff::{ConstantBackoff, ExponentialBackoff};
+    use crate::sleep::FnSleeper;
+
+    #[derive(Debug, PartialEq)]
+    enum TestError {
+        Retryable,
+        Fatal,
+    }
+
+    #[test]
+    fn test_retry_success_on_first_attempt() {
+        fn always_succeeds() -> Result<i32, TestError> {
+            Ok(42)
+        }
+
+        let result = always_succeeds
+            .retry(ExponentialBackoff::default())
+            .call_with_sleeper(FnSleeper(|_| {}));
+
+        assert_eq!(result, Ok(42));
+    }
+
+    #[test]
+    fn test_retry_success_after_failures() {
+        use core::cell::Cell;
+
+        let attempts = Cell::new(0);
+
+        let operation = || {
+            let current = attempts.get();
+            attempts.set(current + 1);
+
+            if current < 2 {
+                Err(TestError::Retryable)
+            } else {
+                Ok(42)
+            }
+        };
+
+        let result = operation
+            .retry(ExponentialBackoff::default().max_attempts(3))
+            .call_with_sleeper(FnSleeper(|_| {}));
+
+        assert_eq!(result, Ok(42));
+        assert_eq!(attempts.get(), 3);
+    }
+
+    #[test]
+    fn test_retry_exhausted() {
+        fn always_fails() -> Result<i32, TestError> {
+            Err(TestError::Retryable)
+        }
+
+        let result = always_fails
+            .retry(ExponentialBackoff::default().max_attempts(3))
+            .call_with_sleeper(FnSleeper(|_| {}));
+
+        assert_eq!(result, Err(TestError::Retryable));
+    }
+
+    #[test]
+    fn test_retry_when_predicate() {
+        fn fails_with_fatal() -> Result<i32, TestError> {
+            Err(TestError::Fatal)
+        }
+
+        let result = fails_with_fatal
+            .retry(ExponentialBackoff::default())
+            .when(|e| matches!(e, TestError::Retryable))
+            .call_with_sleeper(FnSleeper(|_| {}));
+
+        // Fatal error should not be retried
+        assert_eq!(result, Err(TestError::Fatal));
+    }
+
+    #[test]
+    fn test_retry_notify_callback() {
+        use core::cell::Cell;
+
+        let attempts = Cell::new(0);
+
+        let operation = || {
+            let current = attempts.get();
+            attempts.set(current + 1);
+
+            if current < 2 {
+                Err(TestError::Retryable)
+            } else {
+                Ok(42)
+            }
+        };
+
+        // Custom notify that counts calls
+        fn test_notify(_: &TestError, _: u64) {
+            // In real test would need interior mutability via Cell/RefCell
+            // or external state tracking
+        }
+
+        let result = operation
+            .retry(ExponentialBackoff::default().max_attempts(3))
+            .notify(test_notify)
+            .call_with_sleeper(FnSleeper(|_| {}));
+
+        assert_eq!(result, Ok(42));
+    }
+
+    #[test]
+    fn test_constant_backoff_retry() {
+        use core::cell::Cell;
+
+        let attempts = Cell::new(0);
+
+        let operation = || {
+            let current = attempts.get();
+            attempts.set(current + 1);
+
+            if current < 1 {
+                Err(TestError::Retryable)
+            } else {
+                Ok(42)
+            }
+        };
+
+        let result = operation
+            .retry(ConstantBackoff::new().delay_ms(10).max_attempts(2))
+            .call_with_sleeper(FnSleeper(|_| {}));
+
+        assert_eq!(result, Ok(42));
+        assert_eq!(attempts.get(), 2);
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn test_retry_with_std_sleeper() {
+        use core::cell::Cell;
+
+        let attempts = Cell::new(0);
+
+        let operation = || {
+            let current = attempts.get();
+            attempts.set(current + 1);
+
+            if current < 1 {
+                Err(TestError::Retryable)
+            } else {
+                Ok(42)
+            }
+        };
+
+        let start = std::time::Instant::now();
+        let result = operation
+            .retry(
+                ConstantBackoff::new()
+                    .delay_ms(10)
+                    .max_attempts(2)
+                    .jitter_factor(0.0),
+            )
+            .call();
+
+        let elapsed = start.elapsed();
+
+        assert_eq!(result, Ok(42));
+        assert!(elapsed.as_millis() >= 9); // At least one 10ms sleep
+    }
+}

--- a/ext/chrono_machines_native/core/src/sleep.rs
+++ b/ext/chrono_machines_native/core/src/sleep.rs
@@ -1,0 +1,97 @@
+//! Sleep abstraction for no_std compatibility
+//!
+//! This module provides traits and implementations for sleeping/delaying
+//! in various environments (std, async, embedded).
+
+/// Trait for sleep/delay implementations
+///
+/// This trait abstracts sleep operations to support different runtime environments:
+/// - Standard library blocking sleep
+/// - Tokio/async-std async sleep
+/// - Embassy timer for embedded
+/// - Custom implementations
+pub trait Sleeper {
+    /// Sleep for the specified number of milliseconds
+    fn sleep_ms(&self, ms: u64);
+}
+
+/// Standard library sleeper using `std::thread::sleep`
+///
+/// Only available when the `std` feature is enabled.
+///
+/// # Example
+///
+/// ```rust
+/// use chrono_machines::sleep::StdSleeper;
+/// use chrono_machines::sleep::Sleeper;
+///
+/// let sleeper = StdSleeper;
+/// sleeper.sleep_ms(100); // Sleep for 100ms
+/// ```
+#[cfg(feature = "std")]
+#[derive(Debug, Clone, Copy)]
+pub struct StdSleeper;
+
+#[cfg(feature = "std")]
+impl Sleeper for StdSleeper {
+    fn sleep_ms(&self, ms: u64) {
+        std::thread::sleep(std::time::Duration::from_millis(ms));
+    }
+}
+
+/// Function pointer sleeper for custom sleep implementations
+///
+/// Wraps a function pointer that takes milliseconds and performs sleep.
+/// Useful for async runtimes or testing.
+///
+/// # Example
+///
+/// ```rust
+/// use chrono_machines::sleep::{FnSleeper, Sleeper};
+///
+/// // Custom sleep function
+/// fn my_sleep(ms: u64) {
+///     // Custom implementation
+///     std::thread::sleep(std::time::Duration::from_millis(ms));
+/// }
+///
+/// let sleeper = FnSleeper(my_sleep);
+/// sleeper.sleep_ms(100);
+/// ```
+#[derive(Clone, Copy)]
+pub struct FnSleeper(pub fn(u64));
+
+impl Sleeper for FnSleeper {
+    fn sleep_ms(&self, ms: u64) {
+        (self.0)(ms);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn test_std_sleeper() {
+        let sleeper = StdSleeper;
+        let start = std::time::Instant::now();
+        sleeper.sleep_ms(10);
+        let elapsed = start.elapsed();
+
+        // Allow some margin for timing precision
+        assert!(elapsed.as_millis() >= 9 && elapsed.as_millis() <= 20);
+    }
+
+    #[test]
+    fn test_fn_sleeper() {
+        fn test_sleep(ms: u64) {
+            // In a real test, we'd need interior mutability
+            // For this test, we just verify it compiles and runs
+            assert!(ms > 0);
+        }
+
+        let sleeper = FnSleeper(test_sleep);
+        sleeper.sleep_ms(100);
+    }
+}

--- a/ext/chrono_machines_native/extconf.rb
+++ b/ext/chrono_machines_native/extconf.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# Skip native extension compilation on JRuby
+if RUBY_ENGINE == 'jruby'
+  puts 'Skipping native extension compilation on JRuby'
+  puts 'ChronoMachines will use pure Ruby backend'
+  makefile_content = "all:\n\t@echo 'Skipping native extension on JRuby'\n" \
+                     "install:\n\t@echo 'Skipping native extension on JRuby'\n"
+  File.write('Makefile', makefile_content)
+  exit 0
+end
+
+# Check if Cargo is available
+def cargo_available?
+  system('cargo --version > /dev/null 2>&1')
+end
+
+unless cargo_available?
+  warn 'WARNING: Cargo (Rust toolchain) not found!'
+  warn 'ChronoMachines will fall back to pure Ruby backend.'
+  warn 'To enable native performance, install Rust from https://rustup.rs'
+
+  # Create a dummy Makefile that does nothing
+  makefile_content = "all:\n\t@echo 'Skipping native extension (Cargo not found)'\n" \
+                     "install:\n\t@echo 'Skipping native extension (Cargo not found)'\n"
+  File.write('Makefile', makefile_content)
+  exit 0
+end
+
+# Use rb_sys to compile the Rust extension
+require 'mkmf'
+require 'rb_sys/mkmf'
+
+create_rust_makefile('chrono_machines_native/chrono_machines_native') do |r|
+  # Set the path to the FFI crate (relative to current directory)
+  r.ext_dir = 'ffi'
+
+  # Profile configuration
+  r.profile = ENV.fetch('RB_SYS_CARGO_PROFILE', :release).to_sym
+end

--- a/ext/chrono_machines_native/ffi/Cargo.toml
+++ b/ext/chrono_machines_native/ffi/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "chrono_machines_native"
+version = "0.1.0"
+edition = "2024"
+authors = ["Abdelkader Boudih <terminale@gmail.com>"]
+license = "MIT"
+description = "Ruby FFI binding for chrono_machines"
+repository = "https://github.com/seuros/chrono_machines"
+
+[lib]
+name = "chrono_machines_native"
+crate-type = ["cdylib"]
+
+[dependencies]
+chrono_machines = { workspace = true, features = ["std"] }
+magnus = { version = "0.7", features = ["embed"] }
+rand = { workspace = true }
+
+[features]
+default = ["std"]
+std = ["chrono_machines/std"]

--- a/ext/chrono_machines_native/ffi/src/lib.rs
+++ b/ext/chrono_machines_native/ffi/src/lib.rs
@@ -1,0 +1,70 @@
+//! Ruby FFI binding for chrono_machines
+//!
+//! This crate provides a Magnus-based Ruby binding for the chrono_machines library.
+//! It exposes a simple helper function for calculating delays with exponential backoff.
+
+use chrono_machines::Policy;
+use magnus::{function, Error, Ruby};
+use rand::rngs::SmallRng;
+use rand::SeedableRng;
+use std::cell::RefCell;
+
+// Thread-local RNG for performance (avoids reseeding from entropy on every call)
+thread_local! {
+    static RNG: RefCell<SmallRng> = RefCell::new(SmallRng::from_entropy());
+}
+
+/// Calculate delay using exponential backoff with configurable jitter
+///
+/// Delegates to chrono_machines::Policy for consistent behavior with the Rust library.
+///
+/// # Arguments
+/// * `attempt` - The current attempt number (1-indexed)
+/// * `base_delay` - Base delay in seconds
+/// * `multiplier` - Exponential multiplier
+/// * `max_delay` - Maximum delay cap in seconds
+/// * `jitter_factor` - Jitter multiplier (0.0 = no jitter, 1.0 = full jitter)
+///
+/// # Returns
+/// Calculated delay in seconds with jitter applied
+fn calculate_delay_native(
+    attempt: i64,
+    base_delay: f64,
+    multiplier: f64,
+    max_delay: f64,
+    jitter_factor: f64,
+) -> f64 {
+    // Convert seconds to milliseconds for Rust core
+    let base_delay_ms = (base_delay * 1000.0) as u64;
+    let max_delay_ms = (max_delay * 1000.0) as u64;
+
+    // Create policy
+    let policy = Policy {
+        max_attempts: 255, // Not used in delay calculation
+        base_delay_ms,
+        multiplier,
+        max_delay_ms,
+    };
+
+    // Calculate delay using thread-local RNG
+    let attempt_u8 = attempt.min(255).max(1) as u8;
+    let delay_ms = RNG.with(|rng| {
+        let mut rng = rng.borrow_mut();
+        policy.calculate_delay_with_rng(attempt_u8, jitter_factor, &mut *rng)
+    });
+
+    // Convert milliseconds back to seconds for Ruby
+    delay_ms as f64 / 1000.0
+}
+
+/// Initialize the Ruby extension
+#[magnus::init]
+fn init(ruby: &Ruby) -> Result<(), Error> {
+    // Create ChronoMachinesNative module
+    let module = ruby.define_module("ChronoMachinesNative")?;
+
+    // Expose the calculate_delay helper function
+    module.define_module_function("calculate_delay", function!(calculate_delay_native, 5))?;
+
+    Ok(())
+}

--- a/lib/chrono_machines.rb
+++ b/lib/chrono_machines.rb
@@ -6,7 +6,7 @@ loader = Zeitwerk::Loader.for_gem
 loader.ignore("#{__dir__}/chrono_machines/errors.rb")
 loader.ignore("#{__dir__}/chrono_machines/async_support.rb")
 loader.ignore("#{__dir__}/chrono_machines/test_helper.rb")
-loader.inflector.inflect("dsl" => "DSL")
+loader.inflector.inflect('dsl' => 'DSL')
 loader.setup
 
 require_relative 'chrono_machines/errors'

--- a/lib/chrono_machines/async_support.rb
+++ b/lib/chrono_machines/async_support.rb
@@ -27,7 +27,8 @@ if async_available
         end
 
         if current_task
-          current_task.sleep(delay)
+          # Use Kernel#sleep which is now fiber-aware in async 2.x
+          sleep(delay)
         else
           original_robust_sleep(delay)
         end

--- a/lib/chrono_machines/native_speedup.rb
+++ b/lib/chrono_machines/native_speedup.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# Optional native speedup for ChronoMachines
+# This file is loaded conditionally and monkey-patches the Executor
+# to use the native Rust implementation for delay calculations.
+
+begin
+  # Try to load the native extension
+  require 'chrono_machines_native/chrono_machines_native'
+
+  # Monkey-patch Executor to use native calculation
+  # Suppress method redefinition warnings
+  original_verbosity = $VERBOSE
+  $VERBOSE = nil
+
+  module ChronoMachines
+    class Executor
+      private
+
+      # Override calculate_delay to use native implementation
+      def calculate_delay(attempts)
+        ChronoMachinesNative.calculate_delay(
+          attempts,
+          @base_delay,
+          @multiplier,
+          @max_delay,
+          normalized_jitter_factor
+        )
+      end
+    end
+  end
+
+  $VERBOSE = original_verbosity
+rescue LoadError
+  # Native extension not available (e.g., on JRuby or failed compilation)
+  # Silently fall back to pure Ruby implementation
+ensure
+  # Restore verbosity even if LoadError occurs
+  $VERBOSE = original_verbosity if defined?(original_verbosity)
+end

--- a/test/async_test.rb
+++ b/test/async_test.rb
@@ -8,7 +8,7 @@ class AsyncTest < Minitest::Test
   def setup
     super
     # Skip async tests if Async is not available (non-MRI Ruby)
-    skip "Async gem not available" unless defined?(Async)
+    skip 'Async gem not available' unless defined?(Async)
   end
 
   def test_async_support_does_not_break_normal_operation
@@ -65,7 +65,7 @@ class AsyncTest < Minitest::Test
     executor = ChronoMachines::Executor.new
 
     result = nil
-    Async do |task|
+    Async do |_task|
       start_time = Time.now
       executor.send(:robust_sleep, 0.005)
       end_time = Time.now

--- a/test/chrono_machines_test.rb
+++ b/test/chrono_machines_test.rb
@@ -134,7 +134,8 @@ class ChronoMachinesTest < Minitest::Test
 
     ChronoMachines.retry(
       max_attempts: 3,
-      base_delay: 0.001, # Very short delay for test
+      base_delay: 0.01, # Short delay for test
+      jitter_factor: 0.5, # 50% jitter ensures delay is always positive (0.5 to 1.0 of base)
       on_retry: lambda { |exception:, attempt:, next_delay:|
         retry_calls << { exception: exception, attempt: attempt, next_delay: next_delay }
       }

--- a/test/executor_test.rb
+++ b/test/executor_test.rb
@@ -92,6 +92,20 @@ class ExecutorTest < Minitest::Test
     assert_raises(ArgumentError) { executor.send(:calculate_delay, 1) }
   end
 
+  def test_sub_millisecond_delay_is_preserved
+    executor = ChronoMachines::Executor.new(
+      base_delay: 0.0004,
+      multiplier: 1,
+      max_delay: 0.001,
+      jitter_factor: 0.5
+    )
+
+    delay = executor.send(:calculate_delay, 1)
+
+    assert_operator delay, :>=, 0.0002
+    assert_operator delay, :<=, 0.0004
+  end
+
   def test_robust_sleep_handles_zero_delay
     executor = ChronoMachines::Executor.new
 

--- a/test/jitter_factor_test.rb
+++ b/test/jitter_factor_test.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require_relative 'test_helper'
+
+class JitterFactorTest < Minitest::Test
+  include ChronoMachines::TestHelper
+
+  def test_jitter_factor_clamping_negative
+    # Negative jitter_factor should be clamped to 0.0
+    executor = ChronoMachines::Executor.new(
+      base_delay: 1.0,
+      multiplier: 1.0,
+      max_delay: 10.0,
+      jitter_factor: -0.5 # Invalid negative value
+    )
+
+    # With jitter_factor clamped to 0.0, delay should always be exactly base_delay
+    delays = 10.times.map { executor.send(:calculate_delay, 1) }
+    delays.each do |delay|
+      assert_in_delta 1.0, delay, 0.001, 'Delay should be exactly base_delay with clamped jitter_factor=0.0'
+    end
+  end
+
+  def test_jitter_factor_clamping_above_one
+    # jitter_factor > 1.0 should be clamped to 1.0
+    executor = ChronoMachines::Executor.new(
+      base_delay: 1.0,
+      multiplier: 1.0,
+      max_delay: 10.0,
+      jitter_factor: 2.0 # Invalid value > 1.0
+    )
+
+    # With jitter_factor clamped to 1.0, delay should be 0 to base_delay
+    delays = 100.times.map { executor.send(:calculate_delay, 1) }
+    delays.each do |delay|
+      assert_operator delay, :>=, 0.0
+      assert_operator delay, :<=, 1.0
+    end
+  end
+
+  def test_jitter_factor_extreme_values
+    # Test extreme values are properly clamped
+    executor = ChronoMachines::Executor.new(
+      base_delay: 1.0,
+      multiplier: 1.0,
+      max_delay: 10.0,
+      jitter_factor: 999.0 # Extreme value
+    )
+
+    # Should behave as jitter_factor=1.0
+    delays = 100.times.map { executor.send(:calculate_delay, 1) }
+    delays.each do |delay|
+      assert_operator delay, :>=, 0.0
+      assert_operator delay, :<=, 1.0
+    end
+  end
+
+  def test_valid_jitter_factor_range
+    # Test that valid values in 0.0..1.0 work correctly
+    [0.0, 0.1, 0.5, 1.0].each do |jitter_factor|
+      executor = ChronoMachines::Executor.new(
+        base_delay: 1.0,
+        multiplier: 1.0,
+        max_delay: 10.0,
+        jitter_factor: jitter_factor
+      )
+
+      delays = 10.times.map { executor.send(:calculate_delay, 1) }
+
+      if jitter_factor.zero?
+        # No jitter: all delays should be exactly base_delay
+        delays.each { |d| assert_in_delta 1.0, d, 0.001 }
+      else
+        # With jitter: delays should be in expected range
+        min_expected = 1.0 * (1.0 - jitter_factor)
+        max_expected = 1.0
+
+        delays.each do |delay|
+          assert_operator delay, :>=, min_expected - 0.001
+          assert_operator delay, :<=, max_expected + 0.001
+        end
+      end
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
-root_lib = File.expand_path('../lib', __dir__)
-$LOAD_PATH.unshift(root_lib) unless $LOAD_PATH.include?(root_lib)
+def add_to_load_path(path)
+  path = File.expand_path(path, __dir__)
+  $LOAD_PATH.unshift(path) unless $LOAD_PATH.include?(path)
+end
 
-native_ext_dir = File.expand_path('../ext', __dir__)
-$LOAD_PATH.unshift(native_ext_dir) if Dir.exist?(native_ext_dir) && !$LOAD_PATH.include?(native_ext_dir)
+add_to_load_path('../lib')
+add_to_load_path('../ext') if Dir.exist?(File.expand_path('../ext', __dir__))
 
 begin
   require 'async'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
+root_lib = File.expand_path('../lib', __dir__)
+$LOAD_PATH.unshift(root_lib) unless $LOAD_PATH.include?(root_lib)
+
+native_ext_dir = File.expand_path('../ext', __dir__)
+$LOAD_PATH.unshift(native_ext_dir) if Dir.exist?(native_ext_dir) && !$LOAD_PATH.include?(native_ext_dir)
 
 begin
   require 'async'


### PR DESCRIPTION
## Summary

Adds optional Rust native speedup to ChronoMachines with a complete standalone retry library.

Published to crates.io: https://crates.io/crates/chrono_machines

## What's New

### 1. Rust Core Crate (chrono_machines)
- Standalone Rust library published to crates.io
- Three backoff strategies: Exponential, Constant, Fibonacci
- Fluent retry API: .retry() extension trait with chainable builders
- Conditional retry: .when() predicate for selective retries  
- Retry notifications: .notify() callbacks
- no_std compatible for embedded systems (ESP32, etc.)
- Custom sleeper support for async runtimes

### 2. Ruby FFI Integration
- Optional native speedup via Magnus
- Graceful fallback to pure Ruby on JRuby/TruffleRuby
- Faster delay calculations with thread-local RNG
- Zero breaking changes to existing API

## API Example (Rust)

```rust
use chrono_machines::{Retryable, ExponentialBackoff};

let result = fetch_data
    .retry(ExponentialBackoff::default())
    .when(|e| e.kind() == ErrorKind::TimedOut)
    .notify(|err, delay_ms| {
        println\!("Retrying after {}ms: {:?}", delay_ms, err);
    })
    .call()?;
```

## Bug Fixes

- Fixed jitter_factor being ignored in delay calculations
- Fixed shared mutation bug in define_policy
- Fixed jitter_factor validation (now clamped to 0.0..1.0)
- Corrected jitter formula implementation

## Breaking Changes

None\! Pure Ruby implementation still works exactly the same.