### PR TITLE
fix: package workspace Cargo manifest so source builds work

### DIFF
--- a/chrono_machines.gemspec
+++ b/chrono_machines.gemspec
@@ -35,11 +35,13 @@ Gem::Specification.new do |spec|
                           lib/**/*.rb
                           sig/**/*.rbs
                           ext/**/*.{rb,rs,toml}
+                          Cargo.toml
+                          Cargo.lock
                           README.md
                           CHANGELOG.md
                           LICENSE.txt
                         ]).select { |f| File.exist?(f) }
-                   .reject { |f| f =~ /\.(bundle|so|dll)\z/ }
+                   .reject { |f| f =~ /\.(bundle|so|dll)\z/ || f.start_with?('ext/chrono_machines_native/target/') }
   spec.require_paths = ['lib']
 
   # Add native extension (only on CRuby/TruffleRuby)


### PR DESCRIPTION
The ffi crate inherits `chrono-machines` from `workspace.dependencies` (fdeca2f), but the packaged gem omitted the root `Cargo.toml`, so any source install (`force_ruby_platform`, or platforms without a prebuilt gem) failed with:

```
error: failed to parse manifest at .../ext/chrono_machines_native/ffi/Cargo.toml
Caused by: error inheriting `chrono-machines` from workspace root manifest's `workspace.dependencies.chrono-machines`
```

Reproduced installing 0.5.0 from rubygems with `force_ruby_platform: true`.

- Package `Cargo.toml` + `Cargo.lock` so workspace inheritance resolves inside the installed gem
- Reject `ext/chrono_machines_native/target/` from the file list — the `ext/**/*.{rb,rs,toml}` glob sweeps local build artifacts into gems built outside CI

Verified: built the gem locally, `gem install`ed from source on arm64-darwin / Ruby 4.0.5 — cargo compiles, `NativeExecutor` loads, retries work.