### PR TITLE
fix: ignore native_speedup.rb in Zeitwerk loader

### DIFF
--- a/lib/chrono_machines.rb
+++ b/lib/chrono_machines.rb
@@ -6,6 +6,7 @@ loader = Zeitwerk::Loader.for_gem
 loader.ignore("#{__dir__}/chrono_machines/errors.rb")
 loader.ignore("#{__dir__}/chrono_machines/async_support.rb")
 loader.ignore("#{__dir__}/chrono_machines/test_helper.rb")
+loader.ignore("#{__dir__}/chrono_machines/native_speedup.rb")
 loader.inflector.inflect('dsl' => 'DSL')
 loader.setup
 

--- a/test/chrono_machines_test.rb
+++ b/test/chrono_machines_test.rb
@@ -266,4 +266,11 @@ class ChronoMachinesDSLTest < Minitest::Test
     assert_equal 'Inline DSL Success!', result
     assert_equal 2, call_count
   end
+
+  def test_eager_loading_does_not_raise
+    # Rails apps eager-load in production via Zeitwerk::Loader.eager_load_all.
+    # Files that don't define the constant Zeitwerk infers (native_speedup.rb
+    # defines NativeExecutor, not NativeSpeedup) must be in the ignore list.
+    Zeitwerk::Loader.eager_load_all
+  end
 end


### PR DESCRIPTION
0.5.x introduced `lib/chrono_machines/native_speedup.rb`, which defines `ChronoMachines::NativeExecutor` — not the `NativeSpeedup` constant Zeitwerk infers from the filename. It's loaded via `require_relative` from `executor.rb` and was never added to the loader's ignore list, so any eager-loading Rails app (i.e. production, or `bin/rails zeitwerk:check`) crashes at boot:

```
NameError: uninitialized constant ChronoMachines::NativeSpeedup
```

Found while upgrading CommonShare to 0.5.1 — `zeitwerk:check` failed immediately.

- Add `native_speedup.rb` to the ignore list (same treatment as `errors.rb`/`async_support.rb`/`test_helper.rb`)
- Regression test via `Zeitwerk::Loader.eager_load_all` (reproduces the NameError without the fix)